### PR TITLE
fixing bug of id dropdowns to maps

### DIFF
--- a/index.py
+++ b/index.py
@@ -104,7 +104,7 @@ def set_display_children(selected_category):
 @app.callback(
     Output('state_projection_graph', 'children'),
     [Input('state_dropdown', 'value'),
-     Input('us_map_dropdown', 'value')]
+     Input('predicted_timeline', 'value')]
 )
 def update_projection(state,val):
     return build_state_projection(state,val)

--- a/projections/projections.py
+++ b/projections/projections.py
@@ -176,7 +176,7 @@ body = dbc.Container(
                                         dbc.Col(
                                             html.Div(
                                                 dcc.Dropdown(
-                                                    id = 'us_map_dropdown',
+                                                    id = 'predicted_timeline',
                                                     options = [{'label': x, 'value': x} for x in cols],
                                                     value = 'Total Detected',
                                                 ),


### PR DESCRIPTION
This was a bug inserted today with the change to projections page where dropdown id does not match graph and therefore does not affect it. 

Fixing ids accordingly.